### PR TITLE
implemented UseDefaultsJsNull mode to read from case class default values

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ libraryDependencies ++= Seq(
   "io.spray" %% "spray-json" % "1.3.2",
   "org.slf4j" % "slf4j-api" % "1.7.12",
   "org.scalatest" %% "scalatest" % "2.2.5" % "test",
-  "com.typesafe.akka" %% "akka-slf4j" % "2.3.12" % "test"
+  "com.typesafe.akka" %% "akka-slf4j" % "2.3.12" % "test",
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value
 ) ++ {
   if (scalaVersion.value.startsWith("2.10.")) Seq(
     compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)


### PR DESCRIPTION
Discussed in #11 - This implements support for default values via an additional `JsNullBehavior`.

This does use reflection so I don't know if you want to merge it or not. As I understand it, the only other way to access this information would be through a macro. I'm not sure of your stance on those either, nor will I pretend I know how to write one :)

Let me know what you think. It's a very useful feature in my opinion but because of the nature of reflection the implementation is a bit hacky. The reflection code is invoked once per `UseDefaultsJsNull` instantiation via a lazy val, so only the first JsValue to be decoded by a given formatter should have a performance impact.