### PR TITLE
make README fragment syntactically correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ object domain {
 object use {
   import domain._
 
-  Foo("foo").toJson              // """{"s":"foo"}"""
-  Faz(Some("meh")).toJson        // """{"o":"meh"}"""
-  Faz(None).toJson               // """{}"""
+  Foo("foo").toJson                // """{"s":"foo"}"""
+  Faz(Some("meh")).toJson          // """{"o":"meh"}"""
+  Faz(None).toJson                 // """{}"""
   (Foo("foo"): SimpleTrait).toJson // """{"type":"Foo","s":"foo"}"""
   (Bar(): SimpleTrait).toJson      // """{"type":"Bar"}"""
   (Baz: SimpleTrait).toJson        // """{"type":"Baz"}"""
-  (Faz(None): SimpleTrait).toJson       // """{"type":"Fuzz"}"""
+  (Faz(None): SimpleTrait).toJson  // """{"type":"Faz"}"""
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,23 +17,23 @@ libraryDependencies += "com.github.fommil" %% "spray-json-shapeless" % "1.2.0"
 import spray.json._
 import fommil.sjs.FamilyFormats._
 
-package domain {
+object domain {
   sealed trait SimpleTrait
   case class Foo(s: String) extends SimpleTrait
   case class Bar() extends SimpleTrait
   case object Baz extends SimpleTrait
   case class Faz(o: Option[String]) extends SimpleTrait
 }
-package use {
+object use {
   import domain._
 
   Foo("foo").toJson              // """{"s":"foo"}"""
   Faz(Some("meh")).toJson        // """{"o":"meh"}"""
   Faz(None).toJson               // """{}"""
-  Foo("foo"): SimpleTrait.toJson // """{"type":"Foo","s":"foo"}"""
-  Bar(): SimpleTrait.toJson      // """{"type":"Bar"}"""
-  Baz: SimpleTrait.toJson        // """{"type":"Baz"}"""
-  Fuzz: SimpleTrait.toJson       // """{"type":"Fuzz"}"""
+  (Foo("foo"): SimpleTrait).toJson // """{"type":"Foo","s":"foo"}"""
+  (Bar(): SimpleTrait).toJson      // """{"type":"Bar"}"""
+  (Baz: SimpleTrait).toJson        // """{"type":"Baz"}"""
+  (Faz(None): SimpleTrait).toJson       // """{"type":"Fuzz"}"""
 }
 ```
 


### PR DESCRIPTION
Not sure if this sends the same message you originally had in mind, but I edited the fragment on my own until I got it to compile.