### PR TITLE
add AlwaysJsNullsTolerateAbsent ProductHint

### DIFF
--- a/src/main/scala/fommil/sjs/FamilyFormats.scala
+++ b/src/main/scala/fommil/sjs/FamilyFormats.scala
@@ -365,7 +365,7 @@ trait JsonFormatHints {
   case object JsNullNotNone extends JsNullBehaviour
   /** No values serialising to `JsNull` will be included in the wire format. Ambiguous. */
   case object NeverJsNull extends JsNullBehaviour
-  /** Same as AlwaysJsNull when serialzing, with missing values treated as optional upon deserialization. Ambiguous. */
+  /** Same as AlwaysJsNull when serialising, with missing values treated as optional upon deserialisation. Ambiguous. */
   case object AlwaysJsNullTolerateAbsent extends JsNullBehaviour
 
   trait ProductHint[T] {

--- a/src/main/scala/fommil/sjs/FamilyFormats.scala
+++ b/src/main/scala/fommil/sjs/FamilyFormats.scala
@@ -180,7 +180,7 @@ private[sjs] trait LowPriorityFamilyFormats
           case (None, f) if ph.nulls == AlwaysJsNull =>
             missingFieldError(j)
 
-          case (None, f: OptionFormat[_]) if ph.nulls == JsNullNotNone =>
+          case (None, f: OptionFormat[_]) if ph.nulls == JsNullNotNone || ph.nulls == AlwaysJsNullTolerateAbsent =>
             None.asInstanceOf[Value]
 
           case (Some(JsNull), f: OptionFormat[_]) if ph.nulls == JsNullNotNone =>
@@ -365,6 +365,8 @@ trait JsonFormatHints {
   case object JsNullNotNone extends JsNullBehaviour
   /** No values serialising to `JsNull` will be included in the wire format. Ambiguous. */
   case object NeverJsNull extends JsNullBehaviour
+  /** Same as AlwaysJsNull when serialzing, with missing values treated as optional upon deserialization. Ambiguous. */
+  case object AlwaysJsNullTolerateAbsent extends JsNullBehaviour
 
   trait ProductHint[T] {
     def nulls: JsNullBehaviour = JsNullNotNone


### PR DESCRIPTION
I added a new mode to achieve a specific behavior, but perhaps a more general solution would be to separate the read and write behaviors for `null`s. Although, that might be a little weird, because some combinations might not make sense. This solves part of my issue in https://github.com/fommil/spray-json-shapeless/issues/23.